### PR TITLE
Determinized CEA

### DIFF
--- a/src/cel/cea/CEA.java
+++ b/src/cel/cea/CEA.java
@@ -11,7 +11,7 @@ public class CEA {
 
     int nStates;
     int initState;
-    int finalState;
+    Set<Integer> finalStates;
     Collection<Transition> transitions;
     Set<Label> labelSet;
     Set<EventSchema> eventSchemas;
@@ -26,7 +26,7 @@ public class CEA {
         this();
         nStates = otherCea.nStates;
         initState = otherCea.initState;
-        finalState = otherCea.finalState;
+        finalStates = otherCea.finalStates;
 
         transitions.addAll(
                 otherCea.transitions
@@ -39,11 +39,11 @@ public class CEA {
         eventSchemas.addAll(otherCea.eventSchemas);
     }
 
-    CEA(int nStates, int initState, int finalState){
+    CEA(int nStates, int initState, Set<Integer> finalStates){
         this();
         this.nStates = nStates;
         this.initState = initState;
-        this.finalState = finalState;
+        this.finalStates = finalStates;
     }
 
     public CEA copy() {
@@ -63,7 +63,7 @@ public class CEA {
         StringBuilder stringBuilder = new StringBuilder("CEA(\n")
                 .append("  nStates=").append(nStates).append(",\n")
                 .append("  initState=").append(initState).append(",\n")
-                .append("  finalState=").append(finalState).append(",\n")
+                .append("  finalStates=").append(finalStates.toString()).append(",\n")
                 .append("  transitions=[");
 
         if (transitions.size() > 0){

--- a/src/cel/cea/DeterministicCEA.java
+++ b/src/cel/cea/DeterministicCEA.java
@@ -20,10 +20,11 @@ public class DeterministicCEA extends CEA {
     private Set<List<Integer>> statesLeft;
     private ArrayList<Transition> newTransitions;
     private Integer fromState;
+    private Map<List<Integer>, Integer> newStateNameMap = new HashMap<>();
 
     public DeterministicCEA(CEA toDeterminize) {
 
-//        System.out.println(toDeterminize.toString());
+        System.out.println(toDeterminize.toString());
         long compileTime = System.nanoTime();
 
         addedStates = new HashSet<>();
@@ -81,11 +82,11 @@ public class DeterministicCEA extends CEA {
 
         newTransitions.sort(Transition::compareTo);
         transitions = newTransitions;
-        renameStates();
         compileTime = System.nanoTime() - compileTime;
-        System.out.println("Determinization time: " + ((double) compileTime / 1000000000));
-        /* TODO: MERGE TRANSITIONS WITH EQUAL TO AND FROM STATE */
         mergeTransitions();
+        System.out.println("Determinization time: " + ((double) compileTime / 1000000000));
+//        System.out.println(this.toString());
+        /* TODO: MERGE TRANSITIONS WITH EQUAL TO AND FROM STATE */
         /* TODO: COLLAPSE FINAL STATES */
         collapseFinalStates();
         /* TODO: UPDATE AUTOMATA */
@@ -153,15 +154,12 @@ public class DeterministicCEA extends CEA {
         return transitionFrom;
     }
 
-    private static Integer getNewStateNumber(List<Integer> stateList) {
+    private Integer getNewStateNumber(List<Integer> stateList) {
 
-        Integer res = -1;
-
-        for (Integer state : stateList) {
-            res += (int) Math.pow(2, state);
+        if (!newStateNameMap.containsKey(stateList)) {
+            newStateNameMap.put(stateList, nStates++);
         }
-
-        return res;
+        return newStateNameMap.get(stateList);
     }
 
     /* TODO: REDO ENTIRE FUNCTION TO CONSIDER ONLY VALID COMBINATIONS */
@@ -193,20 +191,9 @@ public class DeterministicCEA extends CEA {
 
     private void mergeTransitions() {
         /* TODO: IMPLEMENT THIS */
-    }
-
-    private void renameStates() {
-        int nStates = 0;
-        for (Integer addedState : addedStates) {
-            newStatesMap.put(addedState, nStates++);
-        }
-        ArrayList<Transition> newTransitions = new ArrayList<>();
         for (Transition t : transitions) {
-            newTransitions.add(t.replaceToState(newStatesMap.get(t.getToState()))
-                    .replaceFromState(newStatesMap.get(t.getFromState())));
+            t.getPredicate().flatten();
         }
-        transitions = newTransitions;
-        this.nStates = nStates;
     }
 
     private void collapseFinalStates() {

--- a/src/cel/cea/DeterministicCEA.java
+++ b/src/cel/cea/DeterministicCEA.java
@@ -21,11 +21,15 @@ public class DeterministicCEA extends CEA {
     private ArrayList<Transition> newTransitions;
     private Integer fromState;
     private Map<List<Integer>, Integer> newStateNameMap = new HashMap<>();
+    private Set<Integer> newFinalStates = new HashSet<>();
 
     public DeterministicCEA(CEA toDeterminize) {
 
-        System.out.println(toDeterminize.toString());
+//        System.out.println(toDeterminize.toString());
         long compileTime = System.nanoTime();
+
+        /* Temporarily set finalstates to toDeterminize's final states */
+        finalStates = toDeterminize.finalStates;
 
         addedStates = new HashSet<>();
 
@@ -85,14 +89,9 @@ public class DeterministicCEA extends CEA {
         compileTime = System.nanoTime() - compileTime;
         mergeTransitions();
         System.out.println("Determinization time: " + ((double) compileTime / 1000000000));
-//        System.out.println(this.toString());
-        /* TODO: MERGE TRANSITIONS WITH EQUAL TO AND FROM STATE */
-        /* TODO: COLLAPSE FINAL STATES */
-        collapseFinalStates();
-        /* TODO: UPDATE AUTOMATA */
-//        finalState = newFinalState;
-//        labelSet = newLabelSet;
-//        eventSchemas = newEventSchemas;
+        labelSet = toDeterminize.labelSet;
+        eventSchemas = toDeterminize.eventSchemas;
+        finalStates = newFinalStates;
     }
 
     private void makeNewTransition(List<Transition> usefulTransitions, List<Transition> currentTransitionList, TransitionType color) {
@@ -124,6 +123,13 @@ public class DeterministicCEA extends CEA {
 
         List<Integer> toStatesList = new ArrayList<>(toStates);
         Integer toState = getNewStateNumber(toStatesList);
+
+        for (Integer dest : toStatesList) {
+            if (finalStates.contains(dest)) {
+                newFinalStates.add(toState);
+                break;
+            }
+        }
         if (!addedStates.contains(toState)) {
             statesLeft.add(toStatesList);
         }

--- a/src/cel/cea/KleeneCEA.java
+++ b/src/cel/cea/KleeneCEA.java
@@ -1,5 +1,9 @@
 package cel.cea;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static java.util.stream.Collectors.toList;
 
 public class KleeneCEA extends CEA {
@@ -11,7 +15,7 @@ public class KleeneCEA extends CEA {
         transitions.addAll(
             transitions
                     .stream()
-                    .filter(transition -> transition.getToState() == finalState)
+                    .filter(transition -> inner.finalStates.contains(transition.getToState()))
                     .map(transition -> transition.replaceToState(initState))
                     .collect(toList())
         );

--- a/src/cel/cea/MinimizedCEA.java
+++ b/src/cel/cea/MinimizedCEA.java
@@ -55,10 +55,8 @@ public class MinimizedCEA extends CEA {
                 newTransitions.add(newTransition);
 
                 newLabelSet.addAll(transition.getLabels());
-                Set<EventSchema> evSch = transition.getEventSchema();
-                if (evSch != null) {
-                    newEventSchemas.addAll(evSch);
-                }
+                EventSchema evSch = transition.getEventSchema();
+                newEventSchemas.add(evSch);
             }
         }
         // Sort transitions

--- a/src/cel/cea/MinimizedCEA.java
+++ b/src/cel/cea/MinimizedCEA.java
@@ -18,8 +18,12 @@ public class MinimizedCEA extends CEA {
 
         for (int q: reachableFromQ0){
             Set<Integer> reachableQ = reachableFrom.get(q);
-            if (reachableQ.contains(toMinimize.finalState))
-                usefulStates.add(q);
+            for (Integer finalState : toMinimize.finalStates) {
+                if (reachableQ.contains(finalState)) {
+                    usefulStates.add(q);
+                    break;
+                }
+            }
         }
 
         // renumber all useful states
@@ -34,8 +38,10 @@ public class MinimizedCEA extends CEA {
 
         // rename initial and final states
         int newInitState = newNames[toMinimize.initState];
-        int newFinalState = newNames[toMinimize.finalState];
-
+        Set<Integer> newFinalState = new HashSet<>();
+        for (Integer finalState : toMinimize.finalStates) {
+            newFinalState.add(newNames[finalState]);
+        }
 
         // rename useless transitions and rename the remaining ones
 
@@ -66,7 +72,7 @@ public class MinimizedCEA extends CEA {
         // update automata
         nStates = newStateN;
         initState = newInitState;
-        finalState = newFinalState;
+        finalStates = newFinalState;
         transitions = newTransitions;
         labelSet = newLabelSet;
         eventSchemas = newEventSchemas;

--- a/src/cel/cea/OrCEA.java
+++ b/src/cel/cea/OrCEA.java
@@ -4,6 +4,12 @@ import cel.cea.predicate.Predicate;
 import cel.cea.transition.Transition;
 import cel.cea.transition.TransitionType;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static java.util.stream.Collectors.toList;
 
 public class OrCEA extends CEA {
@@ -12,7 +18,9 @@ public class OrCEA extends CEA {
         // TODO : remove minimization
         nStates = left.nStates + right.nStates + 2;
         initState = 0;
-        finalState = nStates - 1;
+        int finalState = nStates - 1;
+        finalStates = new HashSet<>();
+        finalStates.add(finalState);
 
         // copy all transitions from left CEA, displacing them one state
         int toDisplaceLeft = 1;
@@ -40,7 +48,7 @@ public class OrCEA extends CEA {
         transitions.addAll(
                 left.transitions
                         .stream()
-                        .filter(transition -> transition.getToState() == left.finalState)
+                        .filter(transition ->  left.finalStates.contains(transition.getToState()))
                         .filter(transition -> transition.getType() == TransitionType.BLACK)
                         .map(transition -> transition.displaceTransition(toDisplaceLeft)
                                 .replaceToState(finalState))
@@ -71,7 +79,7 @@ public class OrCEA extends CEA {
         transitions.addAll(
                 right.transitions
                         .stream()
-                        .filter(transition -> transition.getToState() == right.finalState)
+                        .filter(transition -> right.finalStates.contains(transition.getToState()))
                         .filter(transition -> transition.getType() == TransitionType.BLACK)
                         .map(transition -> transition.displaceTransition(toDisplaceRight)
                                 .replaceToState(finalState))

--- a/src/cel/cea/SelectionCEA.java
+++ b/src/cel/cea/SelectionCEA.java
@@ -10,23 +10,21 @@ import java.util.Set;
 
 public class SelectionCEA extends CEA {
 
-    public SelectionCEA(Set<EventSchema> eventSchema){
+    public SelectionCEA(EventSchema eventSchema){
         this(new Predicate(eventSchema), eventSchema);
     }
 
-    public SelectionCEA(Set<StreamSchema> streamSchema, Set<EventSchema> eventSchema){
+    public SelectionCEA(StreamSchema streamSchema, EventSchema eventSchema){
         this(new Predicate(streamSchema, eventSchema), eventSchema);
     }
 
-    private SelectionCEA(Predicate predicate, Set<EventSchema> eventSchema){
+    private SelectionCEA(Predicate predicate, EventSchema eventSchema){
         super(2, 0, 1);
         transitions.add(new Transition(0,0, Predicate.TRUE_PREDICATE, TransitionType.WHITE));
         transitions.add(new Transition(0,1, predicate, TransitionType.BLACK));
 
-        for (EventSchema evSch : eventSchema) {
-            labelSet.add(evSch.getNameLabel());
-        }
-        eventSchemas.addAll(eventSchema);
+        labelSet.add(eventSchema.getNameLabel());
+        eventSchemas.add(eventSchema);
     }
 
 

--- a/src/cel/cea/SelectionCEA.java
+++ b/src/cel/cea/SelectionCEA.java
@@ -6,7 +6,7 @@ import cel.cea.transition.TransitionType;
 import cel.event.EventSchema;
 import cel.stream.StreamSchema;
 
-import java.util.Set;
+import java.util.HashSet;
 
 public class SelectionCEA extends CEA {
 
@@ -19,7 +19,7 @@ public class SelectionCEA extends CEA {
     }
 
     private SelectionCEA(Predicate predicate, EventSchema eventSchema){
-        super(2, 0, 1);
+        super(2, 0, new HashSet<>(){{add(1);}});
         transitions.add(new Transition(0,0, Predicate.TRUE_PREDICATE, TransitionType.WHITE));
         transitions.add(new Transition(0,1, predicate, TransitionType.BLACK));
 

--- a/src/cel/cea/SequenceCEA.java
+++ b/src/cel/cea/SequenceCEA.java
@@ -1,5 +1,8 @@
 package cel.cea;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+
 import static java.util.stream.Collectors.toList;
 
 public class SequenceCEA extends CEA {
@@ -8,7 +11,8 @@ public class SequenceCEA extends CEA {
         // TODO : copy transitions instead of just moving them
         initState = 0;
         nStates = first.nStates + second.nStates - 1;
-        finalState = nStates - 1;
+        finalStates = new HashSet<>();
+        finalStates.add(nStates - 1);
 
         // add all first CEA transitions
         transitions.addAll(first.transitions);

--- a/src/cel/cea/predicate/AndPredicate.java
+++ b/src/cel/cea/predicate/AndPredicate.java
@@ -17,9 +17,9 @@ public class AndPredicate extends Predicate {
         super(left, right);
     }
 
-    public AndPredicate(Collection<Predicate> preds) {
-        super(preds);
-    }
+//    public AndPredicate(Collection<Predicate> preds) {
+//        super(preds);
+//    }
 
 //    public OrPredicate negate() {
 //        for ()

--- a/src/cel/cea/predicate/OrPredicate.java
+++ b/src/cel/cea/predicate/OrPredicate.java
@@ -15,9 +15,9 @@ public class OrPredicate extends Predicate {
         super(left, right);
     }
 
-    public OrPredicate(Collection<Predicate> preds) {
-        super(preds);
-    }
+//    public OrPredicate(Collection<Predicate> preds) {
+//        super(preds);
+//    }
 
 //    @Override
 //    public boolean overEvent(EventSchema eventSchema) {

--- a/src/cel/cea/predicate/Predicate.java
+++ b/src/cel/cea/predicate/Predicate.java
@@ -3,6 +3,7 @@ package cel.cea.predicate;
 import cel.event.Event;
 import cel.event.EventSchema;
 import cel.event.Label;
+import cel.filter.AndEventFilter;
 import cel.filter.EventFilter;
 import cel.stream.StreamSchema;
 
@@ -14,9 +15,9 @@ public class Predicate {
     public static final Predicate TRUE_PREDICATE = new Predicate();
 
     private Collection<EventFilter> filterCollection;
-    private Set<StreamSchema> streamSchema;
-    private Set<EventSchema> eventSchema;
-    private Collection<Predicate> predicates;
+    private StreamSchema streamSchema;
+    private EventSchema eventSchema;
+    private ArrayList<Predicate> predicates;
     private boolean negated = false;
 
     private Set<Label> labelSet;
@@ -26,27 +27,26 @@ public class Predicate {
         filterCollection = new ArrayList<>();
         labelSet = new HashSet<>();
         predicates = new ArrayList<>();
-        streamSchema = new HashSet<>();
-        eventSchema = new HashSet<>();
         satisfiable = true;
     }
 
-//    public Predicate(HashSet<Label> labels) {
-//        this();
-//        labelSet = labels;
-//    }
-
-    public Predicate(Set<EventSchema> eventSchema) {
+    public Predicate(Set<Label> labels) {
         this();
-        this.eventSchema.addAll(eventSchema);
-        for (EventSchema evSch : eventSchema) {
-            addLabel(evSch.getNameLabel());
-        }
+        labelSet = labels;
     }
 
-    public Predicate(Set<StreamSchema> streamSchema, Set<EventSchema> eventSchema) {
+    public Predicate(EventSchema eventSchema) {
+        this();
+        this.eventSchema = eventSchema;
+        if (eventSchema != null) {
+            addLabel(eventSchema.getNameLabel());
+        }
+
+    }
+
+    public Predicate(StreamSchema streamSchema, EventSchema eventSchema) {
         this(eventSchema);
-        this.streamSchema.addAll(streamSchema);
+        this.streamSchema = streamSchema;
     }
 
 //    public Predicate(Predicate inner) {
@@ -62,16 +62,16 @@ public class Predicate {
         this.addPredicate(p2);
     }
 
-    Predicate(Collection<Predicate> predicates) {
+    Predicate(ArrayList<Predicate> predicates) {
         this();
         this.addPredicates(predicates);
     }
 
-    public Set<EventSchema> getEventSchema() {
+    public EventSchema getEventSchema() {
         return eventSchema;
     }
 
-    private Set<StreamSchema> getStreamSchema() {
+    private StreamSchema getStreamSchema() {
         return streamSchema;
     }
 
@@ -79,12 +79,8 @@ public class Predicate {
         return labelSet;
     }
 
-    public Collection<Collection<EventFilter>> getFilterCollection() {
-        Collection<Collection<EventFilter>> streamSchema = new ArrayList<>();
-        for (Predicate p : predicates) {
-            streamSchema.addAll(p.getFilterCollection());
-        }
-        return streamSchema;
+    public Collection<EventFilter> getFilterCollection() {
+        return filterCollection;
     }
 
     public void addFilter(EventFilter filter) {
@@ -104,27 +100,29 @@ public class Predicate {
     }
 
     public void addPredicate(Predicate p) {
+        if (!satisfiable) {
+            return;
+        }
         if (predicates.size() > 0) {
-            for (Predicate pred : predicates) {
-                if (useless(pred, p)) {
+            for (Predicate predicate : predicates) {
+                if (useless(predicate, p)) {
                     return;
                 }
-                if (unsatisfiable(pred, p)) {
+                if (useless(p, predicate)) {
+                    predicates.remove(predicate);
+                }
+                if (unsatisfiable(predicate, p)) {
                     satisfiable = false;
                     return;
                 }
             }
+            for (Predicate predicate : predicates) {
+                if (merged(predicate, p)) {
+                    return;
+                }
+            }
         }
-        predicates.add(p);
-        Set<StreamSchema> strSch = p.getStreamSchema();
-        Set<EventSchema> evSch = p.getEventSchema();
-        if (strSch != null) {
-            streamSchema.addAll(strSch);
-        }
-        if (evSch != null) {
-            eventSchema.addAll(evSch);
-        }
-        labelSet.addAll(p.getLabelSet());
+        predicates.add(p.copy());
     }
 
     private boolean useless(Predicate p1, Predicate p2) {
@@ -133,8 +131,9 @@ public class Predicate {
             return true;
         }
         if (!p1.negated && p2.negated) {
-            return p1.eventSchema != null && p2.eventSchema != null && !p1.eventSchema.equals(p2.eventSchema);
+            return p1.eventSchema != null && !p1.eventSchema.equals(p2.eventSchema);
         }
+        /* TODO: ADD MORE CASES */
         return false;
     }
 
@@ -144,12 +143,33 @@ public class Predicate {
             return true;
         }
         if (!p1.negated && !p2.negated) {
-            return p1.eventSchema != null && p2.eventSchema != null && !p1.eventSchema.equals(p2.eventSchema);
+            if (p1.eventSchema != null && !p1.eventSchema.equals(p2.eventSchema)) {
+                return true;
+            }
+            for (EventFilter ef1 : p1.getFilterCollection()) {
+                for (EventFilter ef2 : p2.getFilterCollection()) {
+                    if (ef1.equivalentTo(ef2.negate())) {
+                        return true;
+                    }
+                }
+            }
         }
+        if (!p1.negated && p2.negated) {
+            ArrayList<EventFilter> satisfiableFilters = new ArrayList<>(p2.getFilterCollection());
+            for (EventFilter ef1 : p1.getFilterCollection()) {
+                for (EventFilter ef2 : p2.getFilterCollection()) {
+                    if (ef1.dominates(ef2)) {
+                        satisfiableFilters.remove(ef2);
+                    }
+                }
+            }
+            return satisfiableFilters.isEmpty();
+        }
+        /* TODO: ADD MORE CASES */
         return false;
     }
 
-    public void addPredicates(Collection<Predicate> predicates) {
+    private void addPredicates(ArrayList<Predicate> predicates) {
         if (predicates == null) {
             return;
         }
@@ -158,34 +178,8 @@ public class Predicate {
         }
     }
 
-    public Collection<Predicate> getPredicates() {
+    public ArrayList<Predicate> getPredicates() {
         return predicates;
-    }
-
-    //    private boolean validForAttributeTypes(EventFilter filter) {
-//        Map<String, ValueType> attributeTypes = eventSchema.getAttributes();
-//
-//        for (Attribute attribute : filter.getAttributes()){
-//            ValueType valueType= attributeTypes.getOrDefault(attribute.getName(),null);
-//            if (valueType == null){
-//                // Attribute does not exist
-//                return false;
-//            }
-//            boolean validAttribute = false;
-//            for (ValueType filterValueType : filter.getValueTypes()){
-//                if (valueType.interoperableWith(filterValueType)) {
-//                    validAttribute = true;
-//                    break;
-//                }
-//            }
-//            if (!validAttribute) return false;
-//        }
-//        return true;
-//    }
-
-    private void makeFalsePredicate() {
-        filterCollection.clear();
-        satisfiable = false;
     }
 
     public void addLabel(Label label) {
@@ -222,53 +216,117 @@ public class Predicate {
     public boolean equals(Predicate other) {
         if (this == other) return true;
         return this.predicates.equals(other.predicates) &&
-                this.eventSchema.equals(other.eventSchema) &&
-                this.streamSchema.equals(other.streamSchema) &&
+                equalEventSchema(this, other) && equalStreamSchema(this, other) &&
                 this.negated == other.negated &&
                 this.labelSet.equals(other.labelSet) &&
                 new HashSet<>(this.filterCollection).equals(new HashSet<>(other.filterCollection));
     }
 
-    public boolean dominates(Predicate other) {
+    private boolean dominates(Predicate other) {
         if (this.equals(other)) return true;
         if (this.negated != other.negated) return false;
         if (this.filterCollection.size() == 0 && other.filterCollection.size() == 0) {
             return true;
         }
-        if (predicates.size() > 0) {
+        /* TODO: ADD MORE CASES */
+//        if (predicates.size() > 0) {
+//
+//        } else {
+//
+//        }
+        return false;
+    }
 
-        } else {
+    private boolean equalEventSchema(Predicate p1, Predicate p2) {
+        if (p1.eventSchema == null) {
+            return p2.eventSchema == null;
+        }
+        return p1.eventSchema.equals(p2.eventSchema);
+    }
 
+    private boolean equalStreamSchema(Predicate p1, Predicate p2) {
+        if (p1.streamSchema == null) {
+            return p2.streamSchema == null;
+        }
+        return p1.streamSchema.equals(p2.streamSchema);
+    }
+
+    private boolean merged(Predicate p1, Predicate p2) {
+        if (equalEventSchema(p1, p2) && equalStreamSchema(p1, p2)) {
+            if (!p1.negated && p2.negated) {
+                boolean satisfiable = false;
+                ArrayList<EventFilter> filtersToNegate = new ArrayList<>();
+                for (EventFilter filter : p2.getFilterCollection()) {
+                    if (!notRedundant(p1.getFilterCollection(), filter.negate())) {
+                        satisfiable = true;
+                        continue;
+                    }
+                    if (notRedundant(p1.getFilterCollection(), filter)) {
+                        satisfiable = true;
+                        filtersToNegate.add(filter);
+                    }
+                }
+                if (!satisfiable) {
+                    this.satisfiable = false;
+                    return true;
+                }
+                if (filtersToNegate.isEmpty()) {
+                    return true;
+                }
+                EventFilter newFilter;
+                if (filtersToNegate.size() > 1) {
+                    EventFilter temp = filtersToNegate.get(0);
+                    newFilter = new AndEventFilter(temp.getLabel(), filtersToNegate);
+                } else {
+                    newFilter = filtersToNegate.get(0);
+                }
+                p1.addFilter(newFilter.negate());
+                return true;
+            }
+            if (!p1.negated) {
+                for (EventFilter filter : p2.getFilterCollection()) {
+                    if (notRedundant(p1.getFilterCollection(), filter)) {
+                        p1.addFilter(filter);
+                    }
+                }
+                return true;
+            }
         }
         return false;
     }
 
-    public void minimize() {
-        /* TODO: IMPLEMENT THIS */
+    private ArrayList<EventFilter> removeRedundants(ArrayList<EventFilter> filters) {
+        for (int i = 0; i < filters.size(); i++) {
+            for (int j = i + 1; j < filters.size(); j++) {
+                if (filters.get(i).dominates(filters.get(j))) {
+                    filters.remove(j);
+                    }
+                }
+            }
+        return filters;
     }
 
-    public String getStreamNames() {
-        StringBuilder ret = new StringBuilder();
-        int i = 0;
-        for (StreamSchema strSch : streamSchema) {
-            ret.append(strSch.getName());
-            if (++i != streamSchema.size()) {
-                ret.append(", ");
+    public boolean notRedundant(Collection<EventFilter> filters, EventFilter newFilter) {
+        /* checks if filters does not imply newFilter */
+        for (EventFilter filter : filters) {
+            if (filter.dominates(newFilter)) {
+                return false;
             }
         }
-        return ret.toString();
+        return true;
     }
 
-    public String getEventNames() {
-        StringBuilder ret = new StringBuilder();
-        int i = 0;
-        for (EventSchema evSch : eventSchema) {
-            ret.append(evSch.getName());
-            if (++i != eventSchema.size()) {
-                ret.append(", ");
-            }
+    public void flatten() {
+        if (predicates.size() == 1) {
+            Predicate target = predicates.get(0);
+            streamSchema = target.streamSchema;
+            eventSchema = target.eventSchema;
+            negated = target.negated ^ negated;
+            filterCollection = target.filterCollection;
+            labelSet = target.labelSet;
+            satisfiable = true;
+            predicates.clear();
         }
-        return ret.toString();
     }
 
     @Override
@@ -285,8 +343,8 @@ public class Predicate {
                 stringBuilder.append(" ");
             }
         } else {
-            String streamName = streamSchema.size() != 0 ? getStreamNames() : "*";
-            String eventName = eventSchema.size() != 0 ? getEventNames() : "*";
+            String streamName = streamSchema != null ? streamSchema.getName() : "*";
+            String eventName = eventSchema != null ? eventSchema.getName() : "*";
             if (negated) {
                 stringBuilder.append("NotPredicate(");
             } else {

--- a/src/cel/cea/transition/Transition.java
+++ b/src/cel/cea/transition/Transition.java
@@ -63,7 +63,7 @@ public class Transition implements Comparable<Transition> {
         predicate.addFilter(filter);
     }
 
-    public Collection<Collection<EventFilter>> getFilters(){
+    public Collection<EventFilter> getFilters(){
         return predicate.getFilterCollection();
     }
 
@@ -87,7 +87,7 @@ public class Transition implements Comparable<Transition> {
         return predicate.getLabelSet();
     }
 
-    public Set<EventSchema> getEventSchema() {
+    public EventSchema getEventSchema() {
         return predicate.getEventSchema();
     }
 

--- a/src/cel/compiler/visitors/PatternVisitor.java
+++ b/src/cel/compiler/visitors/PatternVisitor.java
@@ -91,20 +91,17 @@ public class PatternVisitor extends CELBaseVisitor<CEA> {
             if (!definedStreams.contains(streamName)){
                 throw new NameError("Stream `" + streamName + "` is not defined", ctx.s_event_name().stream_name());
             }
-            Set<StreamSchema> streamSchema = new HashSet<>();
-            StreamSchema inner = StreamSchema.getSchemaFor(streamName);
-            streamSchema.add(inner);
+            StreamSchema streamSchema = StreamSchema.getSchemaFor(streamName);
 
-            if (!inner.containsEvent(eventName)){
+            if (!streamSchema.containsEvent(eventName)){
                 throw new NameError("Event `" + eventName + "` is not defined within stream `" + streamName + "`",
                         ctx.s_event_name().event_name());
             }
 
             // Create a selection CEA that filters for the given stream
-            Set<EventSchema> eventSchema = new HashSet<>();
-            eventSchema.add(EventSchema.tryGetSchemaFor(eventName));
+            EventSchema eventSchema = EventSchema.tryGetSchemaFor(eventName);
 
-            if (eventSchema.size() == 0){
+            if (eventSchema == null){
                 throw new NameError("Event `" + eventName + "` is not defined", ctx.s_event_name().event_name());
             }
             return new SelectionCEA(streamSchema, eventSchema);
@@ -118,10 +115,9 @@ public class PatternVisitor extends CELBaseVisitor<CEA> {
             }
 
             // Create a selection CEA with no filters
-            Set<EventSchema> eventSchema = new HashSet<>();
-            eventSchema.add(EventSchema.tryGetSchemaFor(eventName));
+            EventSchema eventSchema = EventSchema.tryGetSchemaFor(eventName);
 
-            if (eventSchema.size() == 0){
+            if (eventSchema == null){
                 throw new NameError("Event `" + eventName + "` is not defined", ctx.s_event_name());
             }
             return new SelectionCEA(eventSchema);

--- a/test/query.cel
+++ b/test/query.cel
@@ -5,7 +5,7 @@ DECLARE STREAM S2(T)
 
 SELECT MAX *
 FROM S, S2
-WHERE ( S>T ; H + ; T AS t2 ) AS all_events
+WHERE ( S>T ; H + ; S2>T AS t2 ) AS all_events
 FILTER
     all_events[id NOT IN { 123, 125 }]
     AND


### PR DESCRIPTION
- Changed getNewStateNumber implementation. Now it correctly supports up to 2147483647 states, and supports incomplete non deterministic automatons of more than 31 states.
- Removed even more useless transitions
- Determinized CEA should now properly update the new nStates and finalStates.
- Converted finalStates variable into a Set, as it is not always possible to collapse all final states into one in the deterministic case.
- Merged predicates inside a multipredicate if possible
- Reverted few changes to Predicate class, now if the predicate has children, then the parent sets  streamSchema and eventSchema to null, and empties its filterCollection.